### PR TITLE
[sc-71014] Set upload_reports to false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Action to run MUnit tests. See [test/action.yml](test/action.yml)
 
     # Upload MUnit reports to GitHub Actions Artifacts
     # Default: false
-    upload_reports: false
+    upload_coverage_reports: false
 ```
 
 Basic:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## Mulesoft Actions
 
 ### Set up Mulesoft environment
+
 Action to set up the Mulesoft environment. See [setup/action.yml](setup/action.yml)
 
 #### Usage
@@ -46,6 +47,7 @@ jobs:
 ```
 
 ### Run MUnit tests
+
 Action to run MUnit tests. See [test/action.yml](test/action.yml)
 
 #### Usage
@@ -68,6 +70,10 @@ Action to run MUnit tests. See [test/action.yml](test/action.yml)
     # Required
     # Default: .maven/settings.xml
     maven_settings_path: .maven/settings.xml
+
+    # Upload MUnit reports to GitHub Actions Artifacts
+    # Default: false
+    upload_reports: false
 ```
 
 Basic:
@@ -100,6 +106,7 @@ This project is Copyright (c) 2014 and onwards Nimble. It is free software and m
 [LICENSE]: /LICENSE
 
 ## About
+
 <a href="https://nimblehq.co/">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png">

--- a/test/action.yml
+++ b/test/action.yml
@@ -11,9 +11,9 @@ inputs:
     description: Maven settings file path
     required: true
     default: .maven/settings.xml
-  upload_reports:
+  upload_coverage_reports:
     description: Upload MUnit reports to GitHub Actions Artifacts
-    default: false
+    default: 'false'
 
 runs:
   using: composite
@@ -27,7 +27,7 @@ runs:
 
     - name: Upload MUnit reports
       uses: actions/upload-artifact@v3
-      if: inputs.upload_reports == 'true'
+      if: inputs.upload_coverage_reports == 'true'
       with:
         name: munit-test-reports
         path: target/site/munit/coverage/

--- a/test/action.yml
+++ b/test/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: Maven settings file path
     required: true
     default: .maven/settings.xml
+  upload_reports:
+    description: Upload MUnit reports to GitHub Actions Artifacts
+    default: false
 
 runs:
   using: composite
@@ -24,6 +27,7 @@ runs:
 
     - name: Upload MUnit reports
       uses: actions/upload-artifact@v3
+      if: inputs.upload_reports == 'true'
       with:
         name: munit-test-reports
         path: target/site/munit/coverage/


### PR DESCRIPTION
## What happened 👀

- Disable uploading the MUnit reports to the GitHub Actions Artifacts
- Now it would be off by default
- Can be enabled by adding `upload_coverage_reports: true` parameter when using the test action.

## Insight 📝

N/A

## Proof Of Work 📹

https://github.com/Jollibee-Foods-Corporation/jfc-global-store-proc-api/actions/runs/6334168180?pr=6
