### PR TITLE
[sc-71014] Add shared test workflow

### DIFF
--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -2,6 +2,14 @@ name: Test
 
 on:
   workflow_call:
+    inputs:
+      maven_settings_path:
+        description: Maven settings file path
+        type: string
+      upload_coverage_reports:
+        description: Upload MUnit reports to GitHub Actions Artifacts
+        type: boolean
+        default: false
     secrets:
       NEXUS_USERNAME:
         required: true
@@ -14,7 +22,7 @@ concurrency:
 
 jobs:
   test:
-    name: Run MUnit tests
+    name: Run shared tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,9 +31,10 @@ jobs:
       - name: Set up Mulesoft environment
         uses: nimblehq/mulesoft-actions/setup@v1
 
-      - name: Run tests
+      - name: Run MUnit tests
         uses: nimblehq/mulesoft-actions/test@v1
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          maven_settings_path: .maven/settings.xml
+          maven_settings_path: ${{ inputs.maven_settings_path }}
+          upload_coverage_reports: ${{ inputs.upload_coverage_reports }}

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -6,11 +6,12 @@ on:
       maven_settings_path:
         description: Maven settings file path
         type: string
+        required: true
         default: .maven/settings.xml
       upload_coverage_reports:
         description: Upload MUnit reports to GitHub Actions Artifacts
         type: boolean
-        default: false
+        default: true
     secrets:
       NEXUS_USERNAME:
         required: true

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  workflow_call:
+    secrets:
+      NEXUS_USERNAME:
+        required: true
+      NEXUS_PASSWORD:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run MUnit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Mulesoft environment
+        uses: nimblehq/mulesoft-actions/setup@v1
+
+      - name: Run tests
+        uses: nimblehq/mulesoft-actions/test@v1
+        with:
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          maven_settings_path: .maven/settings.xml

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -6,6 +6,7 @@ on:
       maven_settings_path:
         description: Maven settings file path
         type: string
+        default: .maven/settings.xml
       upload_coverage_reports:
         description: Upload MUnit reports to GitHub Actions Artifacts
         type: boolean

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <h3 align="center">Mulesoft GitHub Actions</h3>
-<p>A collection of composite GitHub actions designed specifically for Mulesoft projects. These actions provide pre-built automation steps and workflows to streamline development, testing, and deployment processes.</p>
+<p> This contains a collection of <a href="#mulesoft-actions">Mulesoft Actions</a> and a pre-defined <a href="#mulesoft-shared-workflows">Mulesoft Shared Workflows</a> that speed up the development process of Mulesoft projects. The pre-defined workflows are a ready-to-use solution which combines the Actions for running task like MUnit tests or deploying Mulesoft projects.</p>
 
 ## Mulesoft Actions
 
@@ -139,6 +139,52 @@ jobs:
           org_id: ${{ secrets.BUSINESS_GROUP_ID }}
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}
+```
+
+## Mulesoft Shared Workflows
+
+### Shared Test Workflow
+
+Workflow to run MUnit tests for Mulesoft projects. See [.github/workflows/shared_test.yml](.github/workflows/shared_test.yml)
+
+#### Usage
+
+```yml
+- uses: nimblehq/mulesoft-actions/.github/workflows/shared_test.yml@v1
+  with:
+    # Maven settings file path
+    # Required
+    # Default: .maven/settings.xml
+    maven_settings_path: .maven/settings.xml
+
+    # Upload MUnit reports to GitHub Actions Artifacts
+    # Default: false
+    upload_coverage_reports: false
+
+  secrets:
+    # Nexus username
+    # Required
+    NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+
+    # Nexus password
+    # Required
+    NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+```
+
+Basic:
+
+```yml
+name: My workflow
+on: [push, pull_request]
+jobs:
+  call_test:
+    uses: nimblehq/mulesoft-actions/.github/workflows/shared_test.yml@v1
+    name: Call test workflow
+    with:
+      upload_coverage_reports: true
+    secrets:
+      NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Workflow to run MUnit tests for Mulesoft projects. See [.github/workflows/shared
     maven_settings_path: .maven/settings.xml
 
     # Upload MUnit reports to GitHub Actions Artifacts
-    # Default: false
-    upload_coverage_reports: false
+    # Default: true
+    upload_coverage_reports: true
 
   secrets:
     # Nexus username
@@ -177,9 +177,9 @@ Basic:
 name: My workflow
 on: [push, pull_request]
 jobs:
-  call_test:
+  trigger_test:
     uses: nimblehq/mulesoft-actions/.github/workflows/shared_test.yml@v1
-    name: Call test workflow
+    name: Trigger the test workflow
     with:
       upload_coverage_reports: true
     secrets:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <h3 align="center">Mulesoft GitHub Actions</h3>
-<p> This contains a collection of <a href="#mulesoft-actions">Mulesoft Actions</a> and a pre-defined <a href="#mulesoft-shared-workflows">Mulesoft Shared Workflows</a> that speed up the development process of Mulesoft projects. The pre-defined workflows are a ready-to-use solution which combines the Actions for running task like MUnit tests or deploying Mulesoft projects.</p>
+<p>A collection of <a href="#mulesoft-actions">Mulesoft Actions</a> and pre-defined <a href="#mulesoft-shared-workflows">Mulesoft Shared Workflows</a> that speed up the development process of Mulesoft projects. The pre-defined workflows are a ready-to-use solution which combines the Actions for running task like MUnit tests or deploying Mulesoft projects.</p>
 
 ## Mulesoft Actions
 

--- a/test/action.yml
+++ b/test/action.yml
@@ -10,9 +10,10 @@ inputs:
   maven_settings_path:
     description: Maven settings file path
     required: true
+    default: .maven/settings.xml
   upload_coverage_reports:
     description: Upload MUnit reports to GitHub Actions Artifacts
-    default: 'false'
+    default: 'true'
 
 runs:
   using: composite

--- a/test/action.yml
+++ b/test/action.yml
@@ -10,7 +10,6 @@ inputs:
   maven_settings_path:
     description: Maven settings file path
     required: true
-    default: .maven/settings.xml
   upload_coverage_reports:
     description: Upload MUnit reports to GitHub Actions Artifacts
     default: 'false'


### PR DESCRIPTION
## What happened 👀

- Create a shared workflow for the Test workflow
- Add documentation to the README

## Insight 📝

- https://docs.github.com/en/actions/using-workflows/reusing-workflows
- We specify the `secrets` instead of using `secrets: inherit` as we don't want the shared workflow has permission to read all our secrets values

## Proof Of Work 📹

https://github.com/Jollibee-Foods-Corporation/jfc-global-client-exp-api/actions/runs/6347173332?pr=4
