### PR TITLE
Add encryptionKey for deploy cloudhub with maven

### DIFF
--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -30,6 +30,8 @@ inputs:
   mule_runtime_version:
     description: Mule runtime version
     default: 4.4.0
+  encryptionKey:
+    description: Encryption key
 
 runs:
   using: composite

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -30,7 +30,7 @@ inputs:
   mule_runtime_version:
     description: Mule runtime version
     default: 4.4.0
-  encryptionKey:
+  encryption_key:
     description: Encryption key
 
 runs:
@@ -47,7 +47,7 @@ runs:
       run: |
         artifactName=${{ inputs.mule_file_path }}
         encryptionKey=${{ inputs.encryption_key }}
-        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey="${encryptionKey}"
+        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey="${encryption_key}"
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -44,7 +44,8 @@ runs:
       shell: bash
       run: |
         artifactName=${{ inputs.mule_file_path }}
-        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName}
+        encryptionKey=${{ inputs.encryption_key }}
+        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey="${encryptionKey}"
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}


### PR DESCRIPTION
## What happened 👀

To use secure properties in CloudHub, we need to set the encryption key when deploy so that the CloudHub can use the value to decrypt in the runtime.


## Insight 📝

add `encryptionKey` as the inputs and deployed flag `-DencryptionKey="${encryptionKey}"`

