### PR TITLE
 Add encryption key option in workflow to test and deploy

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -14,9 +14,6 @@ on:
       mule_runtime_version:
         type: string
         default: 4.4.0
-      encryption_key:
-        type: string
-        required: true
     secrets:
       CONTD_APP_CLIENT_ID:
         required: true
@@ -54,4 +51,3 @@ jobs:
           use_artifact: false
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
           mule_runtime_version: ${{ inputs.mule_runtime_version }}
-          encryption_key: ${{ inputs.ENCRYPTION_KEY }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -54,4 +54,4 @@ jobs:
           use_artifact: false
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
           mule_runtime_version: ${{ inputs.mule_runtime_version }}
-          encryption_key: ${{ inputs.encryption_key }}
+          encryption_key: ${{ inputs.ENCRYPTION_KEY }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -40,7 +40,7 @@ jobs:
           use_artifacts: false
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.2
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -21,7 +21,7 @@ on:
         required: true
       CLOUDHUB_BUSINESS_GROUP_ID:
         required: true
-      ENCRYPTION_KEY_DEV:
+      ENCRYPTION_KEY:
         required: true
 
 jobs:
@@ -53,4 +53,4 @@ jobs:
           use_artifact: false
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
           mule_runtime_version: ${{ inputs.mule_runtime_version }}
-          encryption_key: ${{ secrets.ENCRYPTION_KEY_DEV }}
+          encryption_key: ${{ secrets.ENCRYPTION_KEY }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -14,6 +14,9 @@ on:
       mule_runtime_version:
         type: string
         default: 4.4.0
+      encryption_key:
+        type: string
+        required: true
     secrets:
       CONTD_APP_CLIENT_ID:
         required: true
@@ -51,3 +54,4 @@ jobs:
           use_artifact: false
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
           mule_runtime_version: ${{ inputs.mule_runtime_version }}
+          encryption_key: ${{ inputs.encryption_key }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -43,7 +43,7 @@ jobs:
           use_artifacts: false
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.2
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -21,6 +21,8 @@ on:
         required: true
       CLOUDHUB_BUSINESS_GROUP_ID:
         required: true
+      ENCRYPTION_KEY_DEV:
+        required: true
 
 jobs:
   deploy:
@@ -40,7 +42,7 @@ jobs:
           use_artifacts: false
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.2
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}
@@ -51,3 +53,4 @@ jobs:
           use_artifact: false
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
           mule_runtime_version: ${{ inputs.mule_runtime_version }}
+          encryption_key: ${{ secrets.ENCRYPTION_KEY_DEV }}

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -40,3 +40,4 @@ jobs:
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
           maven_settings_path: ${{ inputs.maven_settings_path }}
           upload_coverage_reports: ${{ inputs.upload_coverage_reports }}
+          encryption_key: ${{ inputs.encryption_key }}

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -17,7 +17,7 @@ on:
         required: true
       NEXUS_PASSWORD:
         required: true
-      ENCRYPTION_KEY_DEV:
+      ENCRYPTION_KEY:
         required: true
 
 
@@ -43,4 +43,4 @@ jobs:
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
           maven_settings_path: ${{ inputs.maven_settings_path }}
           upload_coverage_reports: ${{ inputs.upload_coverage_reports }}
-          encryption_key: ${{ secrets.ENCRYPTION_KEY_DEV }}
+          encryption_key: ${{ secrets.ENCRYPTION_KEY }}

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -12,6 +12,10 @@ on:
         description: Upload MUnit reports to GitHub Actions Artifacts
         type: boolean
         default: true
+      encryption_key:
+        description: Encryption key for secure properties
+        type: string
+        required: true
     secrets:
       NEXUS_USERNAME:
         required: true

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -20,7 +20,6 @@ on:
       ENCRYPTION_KEY:
         required: true
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -12,15 +12,14 @@ on:
         description: Upload MUnit reports to GitHub Actions Artifacts
         type: boolean
         default: true
-      encryption_key:
-        description: Encryption key for secure properties
-        type: string
-        required: true
     secrets:
       NEXUS_USERNAME:
         required: true
       NEXUS_PASSWORD:
         required: true
+      ENCRYPTION_KEY_DEV:
+        required: true
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,4 +43,4 @@ jobs:
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
           maven_settings_path: ${{ inputs.maven_settings_path }}
           upload_coverage_reports: ${{ inputs.upload_coverage_reports }}
-          encryption_key: ${{ inputs.encryption_key }}
+          encryption_key: ${{ secrets.ENCRYPTION_KEY_DEV }}

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: nimblehq/mulesoft-actions/setup@v1
 
       - name: Run MUnit tests
-        uses: nimblehq/mulesoft-actions/test@v1
+        uses: nimblehq/mulesoft-actions/test@v1.2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Action to run MUnit tests. See [test/action.yml](test/action.yml)
 > The Nexus enterprise repository username and password are required to run MUnit tests on the CI server. Refer to this [document](https://docs.mulesoft.com/mule-runtime/4.4/maven-reference#configure-mule-repositories) for more information.
 
 ```yml
-- uses: nimblehq/mulesoft-actions/test@v1
+- uses: nimblehq/mulesoft-actions/test@v1.2
   with:
     # Nexus username
     # Required
@@ -78,6 +78,10 @@ Action to run MUnit tests. See [test/action.yml](test/action.yml)
     # Artifact retention days
     # Default: 1
     retention_days: 1
+
+    # Encryption Key for secure properties
+    # Required
+    encryption_key: ${{ secrets.ENCRYPTION_KEY }}
 ```
 
 Basic:
@@ -96,11 +100,12 @@ jobs:
         uses: nimblehq/mulesoft-actions/setup@v1
 
       - name: Run MUnit tests
-        uses: nimblehq/mulesoft-actions/test@v1
+        uses: nimblehq/mulesoft-actions/test@v1.2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
           maven_settings_path: .maven/settings.xml
+          encryption_key: ${{ secrets.ENCRYPTION_KEY }}
 ```
 
 ### Build with Maven
@@ -168,8 +173,9 @@ Action to deploy to CloudHub 1.0. See [deploy_cloudhub_1_0/action.yml](deploy_cl
           <connectedAppClientId>${CONNECTED_APP_CLIENT_ID}</connectedAppClientId>
           <connectedAppClientSecret>${CONNECTED_APP_CLIENT_SECRET}</connectedAppClientSecret>
           <connectedAppGrantType>client_credentials</connectedAppGrantType>
+          <overrideProperties>false</overrideProperties>
           <properties>
-            <mule.env>${MULE_ENVIRONMENT}</mule.env>
+            <securedKey>${encryptionKey}</securedKey>
           </properties>
         </cloudHubDeployment>
         <!-- End of configuration -->
@@ -180,7 +186,7 @@ Action to deploy to CloudHub 1.0. See [deploy_cloudhub_1_0/action.yml](deploy_cl
 #### Usage
 
 ```yml
-- uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1
+- uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.2
   with:
     # Use artifact from `build` action
     # Default: false
@@ -225,6 +231,10 @@ Action to deploy to CloudHub 1.0. See [deploy_cloudhub_1_0/action.yml](deploy_cl
     # Mule environment
     # Default: production
     mule_environment: production
+
+    # Encryption Key for secure properties
+    # Required
+    encryption_key: ${{ secrets.ENCRYPTION_KEY }}
 ```
 
 Basic:
@@ -249,7 +259,7 @@ jobs:
         id: build
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.2
         with:
           cloudhub_environment: ${{ secrets.CLOUDHUB_ENVIRONMENT }}
           cloudhub_business_group_id: ${{ secrets.CLOUDHUB_BUSINESS_GROUP_ID }}
@@ -261,6 +271,7 @@ jobs:
           connected_app_client_secret: ${{ secrets.CONNECTED_APP_CLIENT_SECRET }
           use_artifact: false
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
+          encryption_key: ${{ secrets.ENCRYPTION_KEY }}
 ```
 
 ### Publish Assets to Anypoint Exchange
@@ -365,7 +376,7 @@ Workflow to run MUnit tests for Mulesoft projects. See [.github/workflows/shared
 #### Usage
 
 ```yml
-- uses: nimblehq/mulesoft-actions/.github/workflows/shared_test.yml@v1
+- uses: nimblehq/mulesoft-actions/.github/workflows/shared_test.yml@v1.2
   with:
     # Maven settings file path
     # Required
@@ -384,6 +395,10 @@ Workflow to run MUnit tests for Mulesoft projects. See [.github/workflows/shared
     # Nexus password
     # Required
     NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+
+    # Encryption Key for secure properties
+    # Required
+    ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
 ```
 
 Basic:
@@ -393,13 +408,14 @@ name: My workflow
 on: [push, pull_request]
 jobs:
   trigger_test:
-    uses: nimblehq/mulesoft-actions/.github/workflows/shared_test.yml@v1
+    uses: nimblehq/mulesoft-actions/.github/workflows/shared_test.yml@v1.2
     name: Trigger the test workflow
     with:
       upload_coverage_reports: true
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+      ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
 ```
 
 ### Shared Deploy Workflow
@@ -411,7 +427,7 @@ Workflow to deploy Mulesoft projects to CloudHub 1.0. See [.github/workflows/sha
 Create a new environment for deployment and set the needed environment variables, secrets.
 
 ```yml
-- uses: nimblehq/mulesoft-actions/.github/workflows/shared_deploy_cloudhub_1_0.yml@v1
+- uses: nimblehq/mulesoft-actions/.github/workflows/shared_deploy_cloudhub_1_0.yml@v1.2
   with:
     # CloudHub application name
     # Required
@@ -441,6 +457,10 @@ Create a new environment for deployment and set the needed environment variables
     # CloudHub business group ID
     # Required
     CLOUDHUB_BUSINESS_GROUP_ID: ${{ secrets.CLOUDHUB_BUSINESS_GROUP_ID }}
+
+    # Encryption Key for secure properties
+    # Required
+    ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
 ```
 
 Basic:
@@ -450,7 +470,7 @@ name: My workflow
 on: [push]
 jobs:
   trigger_deploy:
-    uses: nimblehq/mulesoft-actions/.github/workflows/shared_deploy_cloudhub_1_0.yml@v1
+    uses: nimblehq/mulesoft-actions/.github/workflows/shared_deploy_cloudhub_1_0.yml@v1.2
     name: Trigger the deploy workflow
     with:
       cloudhub_application_name: my-app
@@ -460,6 +480,7 @@ jobs:
       CONTD_APP_CLIENT_ID: ${{ secrets.CONTD_APP_CLIENT_ID }}
       CONTD_APP_CLIENT_SECRET: ${{ secrets.CONTD_APP_CLIENT_SECRET }}
       CLOUDHUB_BUSINESS_GROUP_ID: ${{ secrets.BUSINESS_GROUP_ID }}
+      ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Action to deploy to CloudHub 1.0. See [deploy_cloudhub_1_0/action.yml](deploy_cl
           <connectedAppGrantType>client_credentials</connectedAppGrantType>
           <overrideProperties>false</overrideProperties>
           <properties>
+            <mule.env>${MULE_ENVIRONMENT}</mule.env>
             <securedKey>${encryptionKey}</securedKey>
           </properties>
         </cloudHubDeployment>

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -30,6 +30,8 @@ inputs:
   mule_runtime_version:
     description: Mule runtime version
     default: 4.4.0
+  encryptionKey:
+    description: Encryption key
 
 runs:
   using: composite

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -30,6 +30,9 @@ inputs:
   mule_runtime_version:
     description: Mule runtime version
     default: 4.4.0
+  encryption_key:
+    description: Encryption key for secure properties
+    required: true
 
 runs:
   using: composite
@@ -44,7 +47,7 @@ runs:
       shell: bash
       run: |
         artifactName=${{ inputs.mule_file_path }}
-        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName}
+        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey=${ENCRYPTION_KEY_DEV}
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}
@@ -53,3 +56,4 @@ runs:
         CLOUDHUB_REGION: ${{ inputs.cloudhub_region }}
         CLOUDHUB_APPLICATION_NAME: ${{ inputs.cloudhub_application_name }}
         MULE_RUNTIME_VERSION: ${{ inputs.mule_runtime_version }}
+        ENCRYPTION_KEY_DEV: ${{ inputs.encryption_key }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -30,9 +30,6 @@ inputs:
   mule_runtime_version:
     description: Mule runtime version
     default: 4.4.0
-  encryption_key:
-    description: Encryption key
-    required: true
 
 runs:
   using: composite
@@ -48,7 +45,7 @@ runs:
       run: |
         artifactName=${{ inputs.mule_file_path }}
         encryptionKey=${{ inputs.encryption_key }}
-        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey="${encryption_key}"
+        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName}
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -30,7 +30,7 @@ inputs:
   mule_runtime_version:
     description: Mule runtime version
     default: 4.4.0
-  encryptionKey:
+  encryption_key:
     description: Encryption key
 
 runs:
@@ -47,7 +47,7 @@ runs:
       run: |
         artifactName=${{ inputs.mule_file_path }}
         encryptionKey=${{ inputs.encryption_key }}
-        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey="${encryptionKey}"
+        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey="${encryption_key}"
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -32,6 +32,7 @@ inputs:
     default: 4.4.0
   encryption_key:
     description: Encryption key
+    required: true
 
 runs:
   using: composite

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -44,7 +44,8 @@ runs:
       shell: bash
       run: |
         artifactName=${{ inputs.mule_file_path }}
-        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName}
+        encryptionKey=${{ inputs.encryption_key }}
+        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey="${encryptionKey}"
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -47,7 +47,7 @@ runs:
       shell: bash
       run: |
         artifactName=${{ inputs.mule_file_path }}
-        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey=${ENCRYPTION_KEY_DEV}
+        mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName} -DencryptionKey=${ENCRYPTION_KEY}
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}
@@ -56,4 +56,4 @@ runs:
         CLOUDHUB_REGION: ${{ inputs.cloudhub_region }}
         CLOUDHUB_APPLICATION_NAME: ${{ inputs.cloudhub_application_name }}
         MULE_RUNTIME_VERSION: ${{ inputs.mule_runtime_version }}
-        ENCRYPTION_KEY_DEV: ${{ inputs.encryption_key }}
+        ENCRYPTION_KEY: ${{ inputs.encryption_key }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -44,7 +44,6 @@ runs:
       shell: bash
       run: |
         artifactName=${{ inputs.mule_file_path }}
-        encryptionKey=${{ inputs.encryption_key }}
         mvn deploy -DskipTests -DmuleDeploy -Dartifact=${artifactName}
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}

--- a/test/action.yml
+++ b/test/action.yml
@@ -17,6 +17,9 @@ inputs:
   retention_days:
     description: Artifact retention days
     default: 1
+  encryption_key:
+    description: Encryption key for secure properties
+    required: true
 
 runs:
   using: composite
@@ -27,6 +30,7 @@ runs:
       env:
         NEXUS_USERNAME: ${{ inputs.nexus_username }}
         NEXUS_PASSWORD: ${{ inputs.nexus_password }}
+        securedKey: ${{ inputs.encryption_key }}
 
     - name: Upload MUnit reports
       uses: actions/upload-artifact@v3

--- a/test/action.yml
+++ b/test/action.yml
@@ -25,12 +25,12 @@ runs:
   using: composite
   steps:
     - name: Test with Maven
-      run: mvn test --settings ${{ inputs.maven_settings_path }}
+      run: mvn test --settings ${{ inputs.maven_settings_path }} -DsecuredKey=${ENCRYPTION_KEY}
       shell: bash
       env:
         NEXUS_USERNAME: ${{ inputs.nexus_username }}
         NEXUS_PASSWORD: ${{ inputs.nexus_password }}
-        securedKey: ${{ inputs.encryption_key }}
+        ENCRYPTION_KEY: ${{ inputs.encryption_key }}
 
     - name: Upload MUnit reports
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
## What happened 👀

- To run Munit with CD, we need to run `mvn test` with `securedKey` as an ENV.
- To overwrite properties in pom.xml for deployment, we need to add `-DencryptionKey` when deploy

## Insight 📝

use ENCRYPTION_KEY as the secrets for both `.github/workflows/shared_test.yml` and `.github/workflows/shared_deploy_cloudhub_1_0.yml`



