### PR TITLE
[GT-1753] Add the bump app version

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,54 @@ jobs:
 
 ```
 
+### Bump version for the Mule app
+
+Action to bump version for the Mule app. See [bump_version_app/action.yml](bump_version_app/action.yml)
+
+#### Usage
+
+```yml
+- uses: nimblehq/mulesoft-actions/bump_version_app@v1
+  with:
+    # New version to bump
+    # Required
+    new_version: 1.0.1
+
+    # Committer for the pull request
+    # Required
+    committer: ${{ github.actor }}
+
+    # Assignees for the pull request
+    assignees: ${{ github.actor }}
+
+    # GitHub token for the pull request
+    # Required
+    github_token: ${{ github.token }}
+```
+
+Basic:
+
+```yml
+name: My workflow
+on: [push, pull_request]
+jobs:
+  bump_version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Bump Version
+        uses: nimblehq/mulesoft-actions/bump_version_app@v1
+        with:
+          new_version: ${{ inputs.new_version }}
+          assignees: nimble-bot
+          committer: Nimble Bot <bot@nimblehq.co>
+          github_token: ${{ github.token }}
+
+```
+
 ## Mulesoft Shared Workflows
 
 ### Shared Test Workflow

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Action to bump version for the Mule app. See [bump_version_app/action.yml](bump_
 #### Usage
 
 ```yml
-- uses: nimblehq/mulesoft-actions/bump_version_app@v1
+- uses: nimblehq/mulesoft-actions/bump_version_app@v1.4
   with:
     # New version to bump
     # Required
@@ -407,7 +407,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Bump Version
-        uses: nimblehq/mulesoft-actions/bump_version_app@v1
+        uses: nimblehq/mulesoft-actions/bump_version_app@v1.4
         with:
           new_version: ${{ inputs.new_version }}
           assignees: nimble-bot

--- a/bump_version_app/action.yml
+++ b/bump_version_app/action.yml
@@ -1,0 +1,51 @@
+name: Bump version for Mule app
+description: Bump version for Mule app
+inputs:
+  new_version:
+    description: New version
+    required: true
+  committer:
+    description: Committer for the pull request
+    required: true
+  assignees:
+    description: Assignees for the pull request
+  github_token:
+    description: GitHub token to create the pull request
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set the new version in pom.xml
+      shell: bash
+      run: |
+        awk 'NR==1,/\<version\>.*/{sub(/\<version\>.*/, "<version>${{ inputs.new_version }}</version>")} 1' pom.xml > temp && mv temp pom.xml
+        cat pom.xml
+
+    - name: Create the pull request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        assignees: ${{ inputs.assignees }}
+        token: ${{ inputs.github_token }}
+        commit-message: Bump version to ${{ inputs.new_version }}
+        committer: ${{ inputs.committer }}
+        branch: chore/bump-version-to-${{ inputs.new_version }}
+        delete-branch: true
+        title: "[Chore] Bump version to ${{ inputs.new_version }}"
+        labels: |
+          type : chore
+        body: |
+          ## What happened 👀
+
+          Bump version to ${{ inputs.new_version }}
+
+          ## Insight 📝
+
+          Automatically created by the Bump Version workflow.
+
+          ## Proof Of Work 📹
+
+          On the Files changed tab

--- a/bump_version_app/action.yml
+++ b/bump_version_app/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Set the new version in pom.xml
       shell: bash
       run: |
-        awk 'NR==1,/.*\<\/version\>/{sub(/.*\<\/version\>/, "c${{ inputs.new_version }}</version>")} 1' pom.xml > temp && mv temp pom.xml
+        perl -0777 -pe 's/<version>.*<\/version>/<version>${{ inputs.new_version }}<\/version>/' -i.bak pom.xml
         cat pom.xml
 
     - name: Create the pull request

--- a/bump_version_app/action.yml
+++ b/bump_version_app/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Set the new version in pom.xml
       shell: bash
       run: |
-        awk 'NR==1,/\<version\>.*/{sub(/\<version\>.*/, "<version>${{ inputs.new_version }}</version>")} 1' pom.xml > temp && mv temp pom.xml
+        awk 'NR==1,/.*\<\/version\>/{sub(/.*\<\/version\>/, "c${{ inputs.new_version }}</version>")} 1' pom.xml > temp && mv temp pom.xml
         cat pom.xml
 
     - name: Create the pull request


### PR DESCRIPTION
## What happened 👀

Add the bump mule app version

## Insight 📝

Similar as the `bump_doc_version` which receive the `new_version` input.

Can't use the `sed or awk` command as it doesn't work well, the `perl` work in this case as it update only the first match `<version></version>` tag

## Proof Of Work 📹

On the file changes tab

Tested on the https://github.com/Jollibee-Foods-Corporation/jfc-global-loyalty-proc-api

PR: https://github.com/Jollibee-Foods-Corporation/jfc-global-loyalty-proc-api/pull/18

![image](https://github.com/nimblehq/mulesoft-actions/assets/11751745/4a06a3e1-7ec3-4ac4-a33b-cd5b5edf1a0b)


