### PR TITLE
[GT-3235] Remove the hardcode business Group

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Modify groupId in pom.xml
         shell: bash
         run: |
-          perl -0777 -pe 's/<groupId>b1493a71-3550-4d96-a623-e3f11d038f62<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/g' -i.bak pom.xml
+          perl -0777 -pe 's/<groupId>.*<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/g' -i.bak pom.xml
           cat pom.xml
 
       # Remove when switching to the new Exchange - BUSINESS_GROUP_ID_GLOBAL_2 completely for all ENV (DEV, STAGING, PROD)
@@ -69,7 +69,7 @@ jobs:
         if: ${{ inputs.main_api_interface_path }}
         shell: bash
         run: |
-          perl -0777 -pe 's/resource::b1493a71-3550-4d96-a623-e3f11d038f62/resource::${{ secrets.BUSINESS_GROUP_ID }}/' -i.bak ${{ inputs.main_api_interface_path }}
+          perl -0777 -pe 's/resource::.*/resource::${{ secrets.BUSINESS_GROUP_ID }}/' -i.bak ${{ inputs.main_api_interface_path }}
           cat ${{ inputs.main_api_interface_path }}
 
       - name: Set up Mulesoft environment

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Modify groupId in pom.xml
         shell: bash
         run: |
-          perl -0777 -pe 's/<groupId>.*<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/g' -i.bak pom.xml
+          perl -0777 -pe 's/<groupId>[0-9a-fA-F\-]+<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/g' -i.bak pom.xml
           cat pom.xml
 
       # Remove when switching to the new Exchange - BUSINESS_GROUP_ID_GLOBAL_2 completely for all ENV (DEV, STAGING, PROD)
@@ -69,7 +69,7 @@ jobs:
         if: ${{ inputs.main_api_interface_path }}
         shell: bash
         run: |
-          perl -0777 -pe 's/resource::.*/resource::${{ secrets.BUSINESS_GROUP_ID }}/' -i.bak ${{ inputs.main_api_interface_path }}
+          perl -0777 -pe 's/resource::[0-9a-fA-F\-]+/resource::${{ secrets.BUSINESS_GROUP_ID }}/' -i.bak ${{ inputs.main_api_interface_path }}
           cat ${{ inputs.main_api_interface_path }}
 
       - name: Set up Mulesoft environment

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Modify groupId in pom.xml
         shell: bash
         run: |
-          perl -0777 -pe 's/<groupId>.*<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/' -i.bak pom.xml
+          perl -0777 -pe 's/<groupId>[0-9a-fA-F\-]+<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/' -i.bak pom.xml
           cat pom.xml
 
       - name: Set up Mulesoft environment

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Modify groupId in pom.xml
         shell: bash
         run: |
-          perl -0777 -pe 's/<groupId>b1493a71-3550-4d96-a623-e3f11d038f62<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/' -i.bak pom.xml
+          perl -0777 -pe 's/<groupId>.*<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/' -i.bak pom.xml
           cat pom.xml
 
       - name: Set up Mulesoft environment


### PR DESCRIPTION
## What happened 👀

Adjust based on https://github.com/nimblehq/mulesoft-actions/pull/17/files#r1652080948

## Insight 📝

Replace the `hard-code` business GroupId to a regex `[0-9a-fA-F\-]+`

## Proof Of Work 📹

1/ Tag the same version as before `1.9`
2/ Tested on `publish the asset` workflow -> https://github.com/Jollibee-Foods-Corporation/jfc-global-api-common-module/actions/runs/9658072693
3/ Tested on `deploy to Cloudhub 1.0` workflow -> https://github.com/Jollibee-Foods-Corporation/jfc-global-client-exp-api/actions/runs/9658135742
