### PR TITLE
Add the timeout-minutes

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -31,7 +31,7 @@ on:
         required: false
       timeout_minutes:
         description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
-        type: string
+        type: number
         required: false
         default: 15
     secrets:

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -29,6 +29,11 @@ on:
         description: Main APIKit interface path
         type: string
         required: false
+      timeout-minutes:
+        description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
+        type: string
+        required: false
+        default: 15
     secrets:
       CONTD_APP_CLIENT_ID:
         required: true
@@ -53,6 +58,7 @@ jobs:
   deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -29,7 +29,7 @@ on:
         description: Main APIKit interface path
         type: string
         required: false
-      timeout-minutes:
+      timeout_minutes:
         description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
         type: string
         required: false
@@ -58,7 +58,7 @@ jobs:
   deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -12,6 +12,11 @@ on:
         type: string
         required: true
         default: 4.4.0
+      timeout-minutes:
+        description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
+        type: string
+        required: false
+        default: 15
     secrets:
       CONTD_APP_CLIENT_ID:
         required: true
@@ -24,6 +29,7 @@ jobs:
   deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -14,7 +14,7 @@ on:
         default: 4.4.0
       timeout_minutes:
         description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
-        type: string
+        type: number
         required: false
         default: 15
     secrets:

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -12,7 +12,7 @@ on:
         type: string
         required: true
         default: 4.4.0
-      timeout-minutes:
+      timeout_minutes:
         description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
         type: string
         required: false
@@ -29,7 +29,7 @@ jobs:
   deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -14,7 +14,7 @@ on:
         default: true
       timeout_minutes:
         description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
-        type: string
+        type: number
         required: false
         default: 15
     secrets:

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -12,6 +12,11 @@ on:
         description: Upload MUnit reports to GitHub Actions Artifacts
         type: boolean
         default: true
+      timeout-minutes:
+        description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
+        type: string
+        required: false
+        default: 15
     secrets:
       NEXUS_USERNAME:
         required: true
@@ -34,6 +39,7 @@ jobs:
   test:
     name: Run shared tests
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -12,7 +12,7 @@ on:
         description: Upload MUnit reports to GitHub Actions Artifacts
         type: boolean
         default: true
-      timeout-minutes:
+      timeout_minutes:
         description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
         type: string
         required: false
@@ -39,7 +39,7 @@ jobs:
   test:
     name: Run shared tests
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.timeout-minutes }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Workflow to run MUnit tests for Mulesoft projects. See [.github/workflows/shared
 
     # Timeout in minutes
     # Default: 15
-    timeout-minutes: 10
+    timeout_minutes: 10
 
   secrets:
     # Nexus username
@@ -600,7 +600,7 @@ Create a new environment for deployment and set the needed environment variables
 
     # Timeout in minutes
     # Default: 15
-    timeout-minutes: 10
+    timeout_minutes: 10
 
   secrets:
     # CloudHub connected app client ID

--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ Action to run MUnit tests. See [test/action.yml](test/action.yml)
     # Default: .maven/settings.xml
     maven_settings_path: .maven/settings.xml
 
-    # Timeout in minutes
-    # Default: 15
-    timeout-minutes: 10
-
     # Upload MUnit reports to GitHub Actions Artifacts
     # Default: false
     upload_coverage_reports: false
@@ -519,6 +515,10 @@ Workflow to run MUnit tests for Mulesoft projects. See [.github/workflows/shared
     # Default: true
     upload_coverage_reports: true
 
+    # Timeout in minutes
+    # Default: 15
+    timeout-minutes: 10
+
   secrets:
     # Nexus username
     # Required
@@ -597,6 +597,10 @@ Create a new environment for deployment and set the needed environment variables
     # Required
     # Default: .maven/settings.xml
     maven_settings_path: .maven/settings.xml
+
+    # Timeout in minutes
+    # Default: 15
+    timeout-minutes: 10
 
   secrets:
     # CloudHub connected app client ID

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Action to run MUnit tests. See [test/action.yml](test/action.yml)
     # Default: .maven/settings.xml
     maven_settings_path: .maven/settings.xml
 
+    # Timeout in minutes
+    # Default: 15
+    timeout-minutes: 10
+
     # Upload MUnit reports to GitHub Actions Artifacts
     # Default: false
     upload_coverage_reports: false


### PR DESCRIPTION
## What happened 👀

Add the timeout minutes to these shared workflows

## Insight 📝

As some workflow takes more than expected time (due to an unknown issue) 

- Normal takes less than 10 minutes
- Some issues with the Mule; it takes more than 10 minutes - like [this one](https://github.com/Jollibee-Foods-Corporation/jfc-global-client-exp-api/actions/runs/9791570016/attempts/1), takes 37 minutes

## Proof Of Work 📹

These workflow run on https://github.com/Jollibee-Foods-Corporation/jfc-global-cx-exp-api/pull/19
