### PR TITLE
[GT-3091] Increase the JAVA HEAP memory

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -82,7 +82,7 @@ jobs:
         uses: nimblehq/mulesoft-actions/setup@v1.5
 
       - name: Build with Maven
-        uses: nimblehq/mulesoft-actions/build@v1.5
+        uses: nimblehq/mulesoft-actions/build@v1.10
         id: build
         with:
           use_artifacts: false

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -45,7 +45,7 @@ jobs:
         uses: nimblehq/mulesoft-actions/setup@v1.5
 
       - name: Build with Maven
-        uses: nimblehq/mulesoft-actions/build@v1.5
+        uses: nimblehq/mulesoft-actions/build@v1.10
         id: build
         with:
           use_artifacts: false

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: nimblehq/mulesoft-actions/setup@v1.5
 
       - name: Run MUnit tests
-        uses: nimblehq/mulesoft-actions/test@v1.5
+        uses: nimblehq/mulesoft-actions/test@v1.10
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Action to run MUnit tests. See [test/action.yml](test/action.yml)
 > The Nexus enterprise repository username and password are required to run MUnit tests on the CI server. Refer to this [document](https://docs.mulesoft.com/mule-runtime/4.4/maven-reference#configure-mule-repositories) for more information.
 
 ```yml
-- uses: nimblehq/mulesoft-actions/test@v1.5
+- uses: nimblehq/mulesoft-actions/10
   with:
     # Nexus username
     # Required
@@ -112,7 +112,7 @@ jobs:
         uses: nimblehq/mulesoft-actions/setup@v1
 
       - name: Run MUnit tests
-        uses: nimblehq/mulesoft-actions/test@v1.2
+        uses: nimblehq/mulesoft-actions/test@v1.10
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
@@ -130,7 +130,7 @@ Action to build with Maven. See [build/action.yml](build/action.yml)
 #### Usage
 
 ```yml
-- uses: nimblehq/mulesoft-actions/build@v1.5
+- uses: nimblehq/mulesoft-actions/build@v1.10
   with:
     # Upload build artifacts to GitHub Actions Artifacts
     # Default: true

--- a/build/action.yml
+++ b/build/action.yml
@@ -40,6 +40,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Increase JAVA HEAP size
+      shell: bash
+      run: echo "JAVA_TOOL_OPTIONS=-Xmx5g -Xms1g" >> $GITHUB_ENV
+
     - name: Build with Maven
       shell: bash
       run: mvn -B package --settings ${{ inputs.maven_settings_path }} --file pom.xml -DskipMunitTests
@@ -49,6 +53,7 @@ runs:
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}
         NEXUS_USERNAME: ${{ inputs.nexus_username }}
         NEXUS_PASSWORD: ${{ inputs.nexus_password }}
+        JAVA_TOOL_OPTIONS: ${{ env.JAVA_TOOL_OPTIONS }}
 
     - name: Stamp artifact file name with commit hash
       shell: bash

--- a/test/action.yml
+++ b/test/action.yml
@@ -33,6 +33,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Increase JAVA HEAP size
+      shell: bash
+      run: echo "JAVA_TOOL_OPTIONS=-Xmx5g -Xms1g" >> $GITHUB_ENV
+
     - name: Test with Maven
       run: mvn test --settings ${{ inputs.maven_settings_path }} -DsecuredKey=${ENCRYPTION_KEY}
       shell: bash
@@ -43,6 +47,7 @@ runs:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}
+        JAVA_TOOL_OPTIONS: ${{ env.JAVA_TOOL_OPTIONS }}
 
     - name: Upload MUnit reports
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
## What happened 👀

Increase the JAVA Memory heap limit to speed up the Build and Test

## Insight 📝

1/ Default RAM on Github CI is 8 Gb
2/ Just increase the HEAP to `Min: 1GB, Max 5GB` - there was no reason for the `min and max value` there; we just chose the number there.
_3/ Note: We are testing an option with `Min: 3Gb, Max: 5GB` to see if we can have the CI running faster or not, resulting: it's the same, so we will go with `min: 1GB`_

![image](https://github.com/user-attachments/assets/a86d1ac6-f409-466d-84b3-bd0a4c8efc50)


## Proof Of Work 📹

Tested on the project - the CI was reduced from `unlimited - more than 1 hour` to just `7 minutes` 🎉
