### PR TITLE
[GT-3300] Enable logging for DEV/STAGING

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -25,6 +25,11 @@ on:
         type: string
         required: false
         default: '1'
+      http_log_level:
+        description: HTTP Log Level (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL)
+        type: string
+        required: false
+        default: 'OFF'
       main_api_interface_path:
         description: Main APIKit interface path
         type: string
@@ -113,3 +118,4 @@ jobs:
           new_relic_api_key: ${{ secrets.NEW_RELIC_API_KEY }}
           maven_settings_path: ${{ inputs.maven_settings_path }}
           number_of_workers: ${{ inputs.number_of_workers }}
+          http_log_level: ${{ inputs.http_log_level }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -84,10 +84,10 @@ jobs:
           cat ${{ inputs.main_api_interface_path }}
 
       - name: Set up Mulesoft environment
-        uses: nimblehq/mulesoft-actions/setup@v1.5
+        uses: nimblehq/mulesoft-actions/setup@v1.11.0
 
       - name: Build with Maven
-        uses: nimblehq/mulesoft-actions/build@v1.10
+        uses: nimblehq/mulesoft-actions/build@v1.11.0
         id: build
         with:
           use_artifacts: false
@@ -99,7 +99,7 @@ jobs:
           maven_settings_path: ${{ inputs.maven_settings_path }}
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.9
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.11.0
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: Number of workers
     required: false
     default: '1'
+  http_log_level:
+    description: HTTP Log Level (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL)
+    required: false
+    default: 'OFF'
 
 runs:
   using: composite
@@ -89,3 +93,4 @@ runs:
         NEXUS_PASSWORD: ${{ inputs.nexus_password }}
         NEW_RELIC_API_KEY: ${{ inputs.new_relic_api_key }}
         NUMBER_OF_WORKERS: ${{ inputs.number_of_workers }}
+        HTTP_LOG_LEVEL: ${{ inputs.http_log_level }}


### PR DESCRIPTION
https://jfc-dcd.atlassian.net/browse/GT-3300

## What happened 👀

Enable logging for DEV/STAGING, by adding a new input parameter for `http_log_level`.

The different levels are shown [here](https://www.digitalocean.com/community/tutorials/log4j2-example-tutorial-configuration-levels-appenders#log4j2-levels).

Related to : https://github.com/Jollibee-Foods-Corporation/jfc-global-order-proc-api/pull/271

## Proof Of Work 📹

N/A