### PR TITLE
[GT-3496] Deploy STAGING workflow uses the wrong branch

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -20,6 +20,10 @@ on:
         type: string
         required: true
         default: .maven/settings.xml
+      checkout_ref:
+        description: The reference used for actions/checkout.
+        type: string
+        required: true
       number_of_workers:
         description: Number of workers
         type: string
@@ -67,6 +71,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
 
       # Remove when switching to the new Exchange - BUSINESS_GROUP_ID_GLOBAL_2 completely for all ENV (DEV, STAGING, PROD)
       - name: Modify groupId in pom.xml
@@ -84,10 +90,10 @@ jobs:
           cat ${{ inputs.main_api_interface_path }}
 
       - name: Set up Mulesoft environment
-        uses: nimblehq/mulesoft-actions/setup@v1.11.0
+        uses: nimblehq/mulesoft-actions/setup@v1.12.0
 
       - name: Build with Maven
-        uses: nimblehq/mulesoft-actions/build@v1.11.0
+        uses: nimblehq/mulesoft-actions/build@v1.12.0
         id: build
         with:
           use_artifacts: false
@@ -99,7 +105,7 @@ jobs:
           maven_settings_path: ${{ inputs.maven_settings_path }}
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.11.0
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.12.0
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}


### PR DESCRIPTION
https://jfc-dcd.atlassian.net/browse/GT-3496

## What happened 👀

Specify the source for `checkout` (otherwise it will default to develop).

Deploy staging works fine when called directly, but _not_ when triggered after the test workflow.

This is because of `workflow_call`, for more explanation check this [StackOverflow](https://stackoverflow.com/questions/63343937/how-to-use-the-github-actions-workflow-run-event) thread.

Also thanks Andy for providing the solution. 

## Insight 📝

From ChatGPT 🤖 

> `${{ github.event.workflow_run.head_branch }}:`

This part refers to the branch that triggered the workflow when it's invoked as a workflow_run event. This is useful when one workflow triggers another workflow, and you want to check out the same branch that triggered the workflow.

> `${{ github.ref }}:`

This part refers to the branch or tag that triggered the current workflow run. If the workflow is triggered directly by a push or pull request event, this will be the reference (branch or tag) for the event.

## Proof Of Work 📹

I tested on `stripe-exp-api`:

1. Set the default branch to `test/deploy`.
2. Create a branch named `test/deploy` and apply changes.
3. Create a new PR and merge it into `test/deploy` to trigger the workflow automatically.

**Reference** : https://github.com/Jollibee-Foods-Corporation/jfc-global-stripe-exp-api/actions/runs/10279218827

<img width="1493" alt="Screenshot 2567-08-07 at 13 24 11" src="https://github.com/user-attachments/assets/07bd21ac-8340-46c2-b3d3-15efdc2ebf54">

<img width="1494" alt="Screenshot 2567-08-07 at 13 27 22" src="https://github.com/user-attachments/assets/da712cc8-699f-434d-b48d-4c1be38d4003">

