### PR TITLE
[GT-3520] Fix warning on bump version

### DIFF
--- a/bump_version_app/action.yml
+++ b/bump_version_app/action.yml
@@ -26,7 +26,7 @@ runs:
         cat pom.xml
 
     - name: Create the pull request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       with:
         assignees: ${{ inputs.assignees }}
         token: ${{ inputs.github_token }}

--- a/bump_version_doc/action.yml
+++ b/bump_version_doc/action.yml
@@ -29,7 +29,7 @@ runs:
         cat ${{ inputs.version_file }}
 
     - name: Create the pull request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       with:
         assignees: ${{ inputs.assignees }}
         token: ${{ inputs.github_token }}


### PR DESCRIPTION
https://jfc-dcd.atlassian.net/browse/GT-3520

## What happened 👀

- [x] Upgrade `peter-evans/create-pull-request` to version 6

## Insight 📝

Cause of the warning come from Node version 16 from `peter-evans/create-pull-request@v5` change to `v6` will use Node version 20
- Reference: https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md#whats-new

## Proof Of Work 📹

[File changed](https://github.com/nimblehq/mulesoft-actions/pull/27/files)
