### PR TITLE
[GT-3728] Update CloudHub deployment workflow to support worker type

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -30,7 +30,7 @@ on:
         required: false
         default: '1'
       worker_type:
-        description: Size of each worker (MICRO (0.1 vCores - default), SMALL (0.2), MEDIUM (1), LARGE (2), XLARGE (4), XXLARGE (8), 4XLARGE (16))
+        description: Size of each worker (MICRO - 0.1 vCores - default), SMALL - 0.2, MEDIUM - 1, LARGE - 2, XLARGE - 4, XXLARGE - 8, 4XLARGE - 16)
         type: string
         required: false
         default: 'MICRO'

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -29,6 +29,11 @@ on:
         type: string
         required: false
         default: '1'
+      worker_type:
+        description: Size of each worker (MICRO (0.1 vCores - default), SMALL (0.2), MEDIUM (1), LARGE (2), XLARGE (4), XXLARGE (8), 4XLARGE (16))
+        type: string
+        required: false
+        default: 'MICRO'
       http_log_level:
         description: HTTP Log Level (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL)
         type: string
@@ -105,7 +110,7 @@ jobs:
           maven_settings_path: ${{ inputs.maven_settings_path }}
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.12.0
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.13.0
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}
@@ -124,4 +129,5 @@ jobs:
           new_relic_api_key: ${{ secrets.NEW_RELIC_API_KEY }}
           maven_settings_path: ${{ inputs.maven_settings_path }}
           number_of_workers: ${{ inputs.number_of_workers }}
+          worker_type: ${{ inputs.worker_type }}
           http_log_level: ${{ inputs.http_log_level }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: Number of workers
     required: false
     default: '1'
+  worker_type:
+    description: Size of each worker (MICRO (0.1 vCores - default), SMALL (0.2), MEDIUM (1), LARGE (2), XLARGE (4), XXLARGE (8), 4XLARGE (16))
+    required: false
+    default: 'MICRO'
   http_log_level:
     description: HTTP Log Level (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL)
     required: false
@@ -93,4 +97,5 @@ runs:
         NEXUS_PASSWORD: ${{ inputs.nexus_password }}
         NEW_RELIC_API_KEY: ${{ inputs.new_relic_api_key }}
         NUMBER_OF_WORKERS: ${{ inputs.number_of_workers }}
+        WORKER_TYPE: ${{ inputs.worker_type }}
         HTTP_LOG_LEVEL: ${{ inputs.http_log_level }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -60,7 +60,7 @@ inputs:
     required: false
     default: '1'
   worker_type:
-    description: Size of each worker (MICRO (0.1 vCores - default), SMALL (0.2), MEDIUM (1), LARGE (2), XLARGE (4), XXLARGE (8), 4XLARGE (16))
+    description: Size of each worker (MICRO - 0.1 vCores - default), SMALL - 0.2, MEDIUM - 1, LARGE - 2, XLARGE - 4, XXLARGE - 8, 4XLARGE - 16)
     required: false
     default: 'MICRO'
   http_log_level:


### PR DESCRIPTION
https://jfc-dcd.atlassian.net/browse/GT-3728

## What happened 👀

Update the `shared_deploy_cloudhub_1_0` workflow and `deploy_cloudhub_1_0` action to support `worker_type` as an optional input

## Insight 📝

- We need to customize the worker type as well as production will use the different worker type with other environments
- https://docs.mulesoft.com/mule-runtime/latest/deploy-to-cloudhub

## Proof Of Work 📹

Please check the workflow here: https://github.com/Jollibee-Foods-Corporation/cbtl-nexus-backend-proc-api/pull/179
