### PR TITLE
Update api-catalog-cli version from `1.1.0` to `1.1.2` and grep search for success message so we can return error otherwise

### DIFF
--- a/publish_assets/action.yml
+++ b/publish_assets/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Install API Catalog CLI
       shell: bash
-      run: npm install -g api-catalog-cli@1.1.0
+      run: npm install -g api-catalog-cli@1.1.2
 
     - name: Publish API docs to Anypoint Exchange
       shell: bash

--- a/publish_assets/action.yml
+++ b/publish_assets/action.yml
@@ -24,4 +24,17 @@ runs:
         ORG_ID: ${{ inputs.org_id }}
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}
-      run: api-catalog publish-asset -d catalog.yaml --organization="$ORG_ID" --client_id="$CONNECTED_APP_CLIENT_ID" --client_secret="$CONNECTED_APP_CLIENT_SECRET"
+      run: |
+        output=$(api-catalog publish-asset -d catalog.yaml \
+          --organization="$ORG_ID" \
+          --client_id="$CONNECTED_APP_CLIENT_ID" \
+          --client_secret="$CONNECTED_APP_CLIENT_SECRET")
+
+        echo "$output"
+        
+        if echo "$output" | grep -E -q "Successfully cataloged|API successfully published"; then
+          echo "Publishing successful."
+        else
+          echo "Publishing failed. Exiting."
+          exit 1
+        fi


### PR DESCRIPTION
## What happened 👀

1. Updated version (didn't notice any difference)
2. `grep` search for success message, if doesn't exist then `exit 1` (return error)

https://docs.mulesoft.com/release-notes/api-catalog/api-catalog-release-notes

<img width="826" alt="Screenshot 2024-09-19 at 10 17 26" src="https://github.com/user-attachments/assets/233b5ece-75f7-4717-9cce-1a93d9292789">


## Insight 📝

`N/A`

## Proof Of Work 📹

Tested on:
- https://github.com/Jollibee-Foods-Corporation/jfc-global-exp-api-doc/pull/355

Failure (path incorrect):

https://github.com/Jollibee-Foods-Corporation/jfc-global-exp-api-doc/actions/runs/10952458848/job/30411172060

<img width="1512" alt="Screenshot 2024-09-20 at 10 09 35" src="https://github.com/user-attachments/assets/85ca8212-5ce4-4bc0-8f0a-a79fc6135e3c">

Success:

https://github.com/Jollibee-Foods-Corporation/jfc-global-exp-api-doc/actions/runs/10952513309/job/30411320471

<img width="1446" alt="Screenshot 2024-09-20 at 10 14 42" src="https://github.com/user-attachments/assets/8ebd2e77-cef7-4312-b010-1b871db83f43">


