### PR TITLE
[GT-3566] Add new field for release channel

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -15,6 +15,11 @@ on:
         type: string
         required: true
         default: 4.4.0
+      release_channel:
+        description: Release Channel (NONE, EDGE, LTS)
+        type: string
+        required: false
+        default: 'NONE'
       maven_settings_path:
         description: Maven settings file path
         type: string
@@ -123,6 +128,7 @@ jobs:
           use_artifact: false
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
           mule_runtime_version: ${{ inputs.mule_runtime_version }}
+          release_channel: ${{ inputs.release_channel }}
           encryption_key: ${{ secrets.ENCRYPTION_KEY }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -12,6 +12,11 @@ on:
         type: string
         required: true
         default: 4.4.0
+      release_channel:
+        description: Release Channel (NONE, EDGE, LTS)
+        type: string
+        required: false
+        default: 'NONE'
       timeout_minutes:
         description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
         type: number
@@ -69,3 +74,4 @@ jobs:
           business_group_id: ${{ secrets.BUSINESS_GROUP_ID }}
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
           mule_runtime_version: ${{ inputs.mule_runtime_version }}
+          release_channel: ${{ inputs.release_channel }}

--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ Action to deploy to CloudHub 1.0. See [deploy_cloudhub_1_0/action.yml](deploy_cl
     # Required
     mule_runtime_version: 4.4.0
 
+    # Release channel
+    # Default: NONE
+    release_channel: NONE
+
     # Mule environment
     # Default: production
     mule_environment: production
@@ -337,6 +341,7 @@ jobs:
           business_group_id: ${{ secrets.BUSINESS_GROUP_ID }}
           cloudhub_region: ${{ secrets.CLOUDHUB_REGION }}
           mule_runtime_version: ${{ secrets.MULE_VERSION }}
+          release_channel: ${{ secrets.RELEASE_CHANNEL }}
           mule_environment: ${{ secrets.MULE_ENVIRONMENT }}
           application_name: ${{ secrets.APPLICATION_NAME }}
           connected_app_client_id: ${{ secrets.CONNECTED_APP_CLIENT_ID }}
@@ -592,6 +597,10 @@ Create a new environment for deployment and set the needed environment variables
     # Default: 4.4.0
     # Required
     mule_runtime_version: 4.4.0
+
+    # Release channel
+    # Default: NONE
+    release_channel: NONE
 
     # Maven settings file path
     # Required

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -39,6 +39,11 @@ inputs:
     description: Mule runtime version
     required: true
     default: 4.4.0
+  release_channel:
+    description: Release Channel (NONE, EDGE, LTS)
+    type: string
+    required: false
+    default: 'NONE'
   encryption_key:
     description: Encryption key for secure properties
     required: true
@@ -92,6 +97,7 @@ runs:
         CLOUDHUB_REGION: ${{ inputs.cloudhub_region }}
         CLOUDHUB_APPLICATION_NAME: ${{ inputs.cloudhub_application_name }}
         MULE_RUNTIME_VERSION: ${{ inputs.mule_runtime_version }}
+        RELEASE_CHANNEL: ${{ inputs.release_channel }}
         ENCRYPTION_KEY: ${{ inputs.encryption_key }}
         NEXUS_USERNAME: ${{ inputs.nexus_username }}
         NEXUS_PASSWORD: ${{ inputs.nexus_password }}

--- a/deploy_exchange/action.yml
+++ b/deploy_exchange/action.yml
@@ -20,6 +20,11 @@ inputs:
     description: Mule runtime version
     required: true
     default: 4.4.0
+  release_channel:
+    description: Release Channel (NONE, EDGE, LTS)
+    type: string
+    required: false
+    default: 'NONE'
 
 runs:
   using: composite
@@ -32,4 +37,5 @@ runs:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}
         MULE_RUNTIME_VERSION: ${{ inputs.mule_runtime_version }}
+        RELEASE_CHANNEL: ${{ inputs.release_channel }}
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}


### PR DESCRIPTION
## What happened 👀

[I can't deploy to Cloudhub](https://github.com/Jollibee-Foods-Corporation/jfc-global-loyalty-proc-api/actions/runs/11123177782/job/30906075132) after upgrading to a newer Mule Runtime version.

I believe this is because we need to specify the release channel. (I'm not 100% sure):

- https://docs.mulesoft.com/mule-runtime/latest/deploy-to-cloudhub#cloudhub-deploy-reference
- https://docs.mulesoft.com/release-notes/mule-runtime/lts-edge-release-cadence
- https://docs.mulesoft.com/release-notes/runtime-fabric/runtime-fabric-runtimes-release-notes#september-3-2024

<img width="817" alt="Screenshot 2567-10-01 at 17 25 48" src="https://github.com/user-attachments/assets/75d8e1c7-aabb-4dbf-b51b-db2fe20fe78f">

<img width="843" alt="Screenshot 2567-10-01 at 17 25 10" src="https://github.com/user-attachments/assets/5f15719d-5316-4e05-836a-cf4ed005d7d0">

## Proof Of Work 📹

N/A