### PR TITLE
[GT-4354] Skip the CI on Bump the version

### DIFF
--- a/bump_version_app/action.yml
+++ b/bump_version_app/action.yml
@@ -30,7 +30,7 @@ runs:
       with:
         assignees: ${{ inputs.assignees }}
         token: ${{ inputs.github_token }}
-        commit-message: [skip ci] Bump version to ${{ inputs.new_version }}
+        commit-message: "[skip ci] Bump version to ${{ inputs.new_version }}"
         committer: ${{ inputs.committer }}
         branch: chore/bump-version-to-${{ inputs.new_version }}
         delete-branch: true

--- a/bump_version_app/action.yml
+++ b/bump_version_app/action.yml
@@ -30,7 +30,7 @@ runs:
       with:
         assignees: ${{ inputs.assignees }}
         token: ${{ inputs.github_token }}
-        commit-message: Bump version to ${{ inputs.new_version }}
+        commit-message: [skip ci] Bump version to ${{ inputs.new_version }}
         committer: ${{ inputs.committer }}
         branch: chore/bump-version-to-${{ inputs.new_version }}
         delete-branch: true

--- a/bump_version_doc/action.yml
+++ b/bump_version_doc/action.yml
@@ -33,7 +33,7 @@ runs:
       with:
         assignees: ${{ inputs.assignees }}
         token: ${{ inputs.github_token }}
-        commit-message: Bump version to ${{ inputs.new_version }}
+        commit-message: [skip ci] Bump version to ${{ inputs.new_version }}
         committer: ${{ inputs.committer }}
         branch: chore/bump-version-to-${{ inputs.new_version }}
         delete-branch: true

--- a/bump_version_doc/action.yml
+++ b/bump_version_doc/action.yml
@@ -33,7 +33,7 @@ runs:
       with:
         assignees: ${{ inputs.assignees }}
         token: ${{ inputs.github_token }}
-        commit-message: [skip ci] Bump version to ${{ inputs.new_version }}
+        commit-message: "[skip ci] Bump version to ${{ inputs.new_version }}"
         committer: ${{ inputs.committer }}
         branch: chore/bump-version-to-${{ inputs.new_version }}
         delete-branch: true


### PR DESCRIPTION
- Close #

## What happened 👀

Skip the CI on the Bump version PRs

## Insight 📝

The CI can be skipped by adding the `[skip ci]` prefix

Ref => https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs

## Proof Of Work 📹

Test on https://github.com/Jollibee-Foods-Corporation/jfc-global-user-proc-api/pull/205

No CI run with the `[skip ci]` prefix

<img width="856" alt="image" src="https://github.com/user-attachments/assets/da8568d8-9c51-492a-b6c2-a1bee4bd8985">


<img width="916" alt="image" src="https://github.com/user-attachments/assets/698593e4-b2b7-42c6-af4a-ed4eb710a6cc">
