### PR TITLE
Check for `no variable` in RemoveVariable component from the log

### DIFF
--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -54,7 +54,7 @@ jobs:
           java_version: ${{ inputs.java_version }}
 
       - name: Run MUnit tests
-        uses: nimblehq/mulesoft-actions/test@v1.16.0
+        uses: nimblehq/mulesoft-actions/test@v1.19.0
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/test/action.yml
+++ b/test/action.yml
@@ -35,10 +35,10 @@ runs:
   steps:
     - name: Increase JAVA HEAP size
       shell: bash
-      run: echo "JAVA_TOOL_OPTIONS=-Xmx5g -Xms1g" >> $GITHUB_ENV
+      run: echo "JAVA_TOOL_OPTIONS=-Xmx5g -Xms2g" >> $GITHUB_ENV
 
     - name: Test with Maven
-      run: mvn test --settings ${{ inputs.maven_settings_path }} -DsecuredKey=${ENCRYPTION_KEY}
+      run: mvn test --settings ${{ inputs.maven_settings_path }} -DsecuredKey=${ENCRYPTION_KEY} > munit-test-output.log 2>&1
       shell: bash
       env:
         NEXUS_USERNAME: ${{ inputs.nexus_username }}
@@ -56,3 +56,18 @@ runs:
         name: munit-test-reports
         path: target/site/munit/coverage/
         retention-days: ${{ inputs.retention_days }}
+
+    - name: Upload MUnit Output
+      uses: actions/upload-artifact@v4
+      with:
+        name: munit-test-output
+        path: munit-test-output.log
+        retention-days: ${{ inputs.retention_days }}
+
+    - name: Check for no variable for RemoveFlowVariableProcessor in the log
+      run: |
+        if grep -q "Check the 'variableName' parameter in the 'remove-variable' component" munit-test-output.log; then
+          echo "Error: No variable found for RemoveFlowVariableProcessor. Please check the `munit-test-output.log` and search with `There is no variable named` term from the log."
+          exit 1
+        fi
+      shell: bash

--- a/test/action.yml
+++ b/test/action.yml
@@ -49,18 +49,18 @@ runs:
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}
         JAVA_TOOL_OPTIONS: ${{ env.JAVA_TOOL_OPTIONS }}
 
-    - name: Upload MUnit reports
+    - name: Upload MUnit coverage reports
       uses: actions/upload-artifact@v4
       if: inputs.upload_coverage_reports == 'true'
       with:
-        name: munit-test-reports
+        name: munit-test-coverage-reports
         path: target/site/munit/coverage/
         retention-days: ${{ inputs.retention_days }}
 
-    - name: Upload MUnit Output
+    - name: Upload MUnit output
       uses: actions/upload-artifact@v4
       with:
-        name: munit-test-output
+        name: munit-test-log-output
         path: munit-test-output.log
         retention-days: ${{ inputs.retention_days }}
 

--- a/test/action.yml
+++ b/test/action.yml
@@ -64,10 +64,14 @@ runs:
         path: munit-test-output.log
         retention-days: ${{ inputs.retention_days }}
 
+    - name: Load the MUnit log to StdOut
+      shell: bash
+      run: cat munit-test-output.log
+
     - name: Check for no variable for RemoveFlowVariableProcessor in the log
+      shell: bash
       run: |
         if grep -q "Check the 'variableName' parameter in the 'remove-variable' component" munit-test-output.log; then
           echo "**Error**: One of the variables is invalid for RemoveFlowVariableProcessor. Please check the 'munit-test-output.log' file and search for the term 'There is no variable named' to locate the issue."
           exit 1
         fi
-      shell: bash

--- a/test/action.yml
+++ b/test/action.yml
@@ -67,7 +67,7 @@ runs:
     - name: Check for no variable for RemoveFlowVariableProcessor in the log
       run: |
         if grep -q "Check the 'variableName' parameter in the 'remove-variable' component" munit-test-output.log; then
-          echo "Error: No variable found for RemoveFlowVariableProcessor. Please check the `munit-test-output.log` and search with `There is no variable named` term from the log."
+          echo "\n**Error**: One of the variables is invalid for RemoveFlowVariableProcessor. Please check the 'munit-test-output.log' file and search for the term 'There is no variable named' to locate the issue."
           exit 1
         fi
       shell: bash

--- a/test/action.yml
+++ b/test/action.yml
@@ -13,18 +13,18 @@ inputs:
     default: .maven/settings.xml
   upload_coverage_reports:
     description: Upload MUnit reports to GitHub Actions Artifacts
-    default: 'true'
+    default: "true"
   retention_days:
     description: Artifact retention days
-    default: '1'
+    default: "1"
   encryption_key:
     description: Encryption key for secure properties
     required: true
   connected_app_client_id:
-    description:  CloudHub connected app client ID
+    description: CloudHub connected app client ID
     required: false
   connected_app_client_secret:
-    description:  CloudHub connected app client secret
+    description: CloudHub connected app client secret
     required: false
   business_group_id:
     description: Business group ID
@@ -67,7 +67,7 @@ runs:
     - name: Check for no variable for RemoveFlowVariableProcessor in the log
       run: |
         if grep -q "Check the 'variableName' parameter in the 'remove-variable' component" munit-test-output.log; then
-          echo "\n**Error**: One of the variables is invalid for RemoveFlowVariableProcessor. Please check the 'munit-test-output.log' file and search for the term 'There is no variable named' to locate the issue."
+          echo "**Error**: One of the variables is invalid for RemoveFlowVariableProcessor. Please check the 'munit-test-output.log' file and search for the term 'There is no variable named' to locate the issue."
           exit 1
         fi
       shell: bash


### PR DESCRIPTION
## What happened 👀

Raise an error if there is an `issue with Remove Variable` in the codebase. Mainly because the Variable name is invalid.

## Insight 📝

As we are starting, apply `remove variable` to all repos, sometimes the developer uses an invalid variableName.

Example on this PR: https://github.com/Jollibee-Foods-Corporation/jfc-global-order-proc-api/pull/610

## Proof Of Work 📹

Tested on https://github.com/Jollibee-Foods-Corporation/jfc-global-order-proc-api/actions/runs/12780673913/job/35627338969

![image](https://github.com/user-attachments/assets/8cbc0b8c-723b-4029-8d74-a74f13836775)

