### PR TITLE
[CBTL-2368] Use the new environment variable to control the log level from JSON Logger

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -39,6 +39,11 @@ on:
         type: string
         required: false
         default: 'OFF'
+      intentional_http_log_level:
+        description: Intentionally or manually added HTTP Log Level (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL)
+        type: string
+        required: false
+        default: 'OFF'
       main_api_interface_path:
         description: Main APIKit interface path
         type: string
@@ -137,3 +142,4 @@ jobs:
           number_of_workers: ${{ inputs.number_of_workers }}
           worker_type: ${{ inputs.worker_type }}
           http_log_level: ${{ inputs.http_log_level }}
+          intentional_http_log_level: ${{ inputs.intentional_http_log_level }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -121,7 +121,7 @@ jobs:
           maven_settings_path: ${{ inputs.maven_settings_path }}
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.16.0
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.20.0
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: HTTP Log Level (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL)
     required: false
     default: 'OFF'
+  intentional_http_log_level:
+    description: Intentionally or manually added HTTP Log Level (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL)
+    required: false
+    default: 'OFF'
 
 runs:
   using: composite
@@ -99,3 +103,4 @@ runs:
         NUMBER_OF_WORKERS: ${{ inputs.number_of_workers }}
         WORKER_TYPE: ${{ inputs.worker_type }}
         HTTP_LOG_LEVEL: ${{ inputs.http_log_level }}
+        INTENTIONAL_HTTP_LOG_LEVEL: ${{ inputs.intentional_http_log_level }}


### PR DESCRIPTION
- https://jfc-dcd.atlassian.net/browse/CBTL-2368

## What happened 👀

- Add a new `intentional_http_log_level` variable to control the custom and intentional logs.
- Set the variable as optional, and default to `OFF`.
- Tag `v1.20.0` for the newly added changes and upgrade to use the new version of the `deploy_cloudhub_1_0` flow.

## Insight 📝

Adds `intentional_http_log_level` configuration to complement existing `http_log_level`. While `http_log_level` controls logging for all HTTP requests to New Relic, the new setting enables separate logging levels specifically for selected System APIs used in integrity verification and error tracing.

## Proof Of Work 📹

Tested in three system APIs
- https://github.com/Jollibee-Foods-Corporation/cbtl-nexus-sessionm-sys-api/pull/102
- https://github.com/Jollibee-Foods-Corporation/cbtl-nexus-braze-sys-api/pull/67
- https://github.com/Jollibee-Foods-Corporation/cbtl-nexus-epoint-sys-api/pull/108
