### PR TITLE
[GT-5166] Add Comment out Log4j2 File Appender step

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -44,10 +44,11 @@ on:
         type: string
         required: false
         default: 'OFF'
-      main_api_interface_path:
-        description: Main APIKit interface path
-        type: string
+      disable_log4j2_file_appender:
+        description: Disable Log4j2 File Appender
+        type: boolean
         required: false
+        default: false
       timeout_minutes:
         description: The maximum number of minutes to let a job run before GitHub automatically cancels it.
         type: number
@@ -88,20 +89,12 @@ jobs:
         with:
           ref: ${{ inputs.checkout_ref }}
 
-      # Remove when switching to the new Exchange - BUSINESS_GROUP_ID_GLOBAL_2 completely for all ENV (DEV, STAGING, PROD)
-      - name: Modify groupId in pom.xml
+      - name: Comment out Log4j2 File Appender
+        if: inputs.disable_log4j2_file_appender == 'true'
         shell: bash
         run: |
-          perl -0777 -pe 's/<groupId>[0-9a-fA-F\-]+<\/groupId>/<groupId>${{ secrets.BUSINESS_GROUP_ID }}<\/groupId>/g' -i.bak pom.xml
-          cat pom.xml
-
-      # Remove when switching to the new Exchange - BUSINESS_GROUP_ID_GLOBAL_2 completely for all ENV (DEV, STAGING, PROD)
-      - name: Modify groupId in Main API Interface
-        if: ${{ inputs.main_api_interface_path }}
-        shell: bash
-        run: |
-          perl -0777 -pe 's/resource::[0-9a-fA-F\-]+/resource::${{ secrets.BUSINESS_GROUP_ID }}/' -i.bak ${{ inputs.main_api_interface_path }}
-          cat ${{ inputs.main_api_interface_path }}
+          perl -0777 -pe 's/<AppenderRef ref="file" \/>/<!-- <AppenderRef ref="file" \/> -->/g' -i.bak src/main/resources/log4j2.xml
+          cat src/main/resources/log4j2.xml
 
       - name: Set up Mulesoft environment
         uses: nimblehq/mulesoft-actions/setup@v1.16.0


### PR DESCRIPTION
## What happened 👀

- Add Comment out Log4j2 File Appender step
- Remove the need of supporter for Business Group 2

## Insight 📝

- Accept a new `disable_log4j2_file_appender` input param
- Comment out the file appender by `perl -0777 -pe 's/<AppenderRef ref="file" \/>/<!-- <AppenderRef ref="file" \/> -->/g' -i.bak src/main/resources/log4j2.xml`

## Proof Of Work 📹

1/ Tested the script locally

![image](https://github.com/user-attachments/assets/cf0ea8b8-8827-4cc0-b998-fb227b38ea73)

2/ From the CI

![image](https://github.com/user-attachments/assets/51a2c784-df66-469e-842a-88ce13cbb7c3)

3/ When the `option is false` it skips the `Comment Log4J2 File Appender` step

![image](https://github.com/user-attachments/assets/9bf24198-f563-4f77-8f60-2b97e4a3d425)
