### PR TITLE
[GT-5447] Add Nexux credentials for the deploy exchange

### DIFF
--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -67,11 +67,13 @@ jobs:
           maven_settings_path: ${{ inputs.maven_settings_path }}
 
       - name: Deploy to Anypoint Exchange
-        uses: nimblehq/mulesoft-actions/deploy_exchange@v1.16.0
+        uses: nimblehq/mulesoft-actions/deploy_exchange@v1.22.0
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}
           maven_settings_path: ${{ inputs.maven_settings_path }}
           business_group_id: ${{ secrets.BUSINESS_GROUP_ID }}
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}
           mule_runtime_version: ${{ inputs.mule_runtime_version }}

--- a/deploy_exchange/action.yml
+++ b/deploy_exchange/action.yml
@@ -16,6 +16,12 @@ inputs:
   mule_file_path:
     description: Mule file path
     required: true
+  nexus_username:
+    description: Nexus username
+    required: false
+  nexus_password:
+    description: Nexus password
+    required: false
   mule_runtime_version:
     description: Mule runtime version
     required: true
@@ -31,5 +37,7 @@ runs:
       env:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}
+        NEXUS_USERNAME: ${{ inputs.nexus_username }}
+        NEXUS_PASSWORD: ${{ inputs.nexus_password }}
         MULE_RUNTIME_VERSION: ${{ inputs.mule_runtime_version }}
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}


### PR DESCRIPTION
https://jfc-dcd.atlassian.net/browse/GT-5447

## What happened 👀

Add Nexus credentials as we need them to fetch the `mule-http-policy-transform-extensio@3.2.0` on https://github.com/Jollibee-Foods-Corporation/jfc-global-api-circuit-breaker-custom-policy/pull/1

## Insight 📝


## Proof Of Work 📹

Show us the implementation: screenshots, GIFs, etc.
