### PR TITLE
[CBTL-2670] Add additional business group ID

### DIFF
--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -99,12 +99,12 @@ jobs:
           cat src/main/resources/log4j2.xml
 
       - name: Set up Mulesoft environment
-        uses: nimblehq/mulesoft-actions/setup@v1.16.0
+        uses: nimblehq/mulesoft-actions/setup@v1.23.0
         with:
           java_version: ${{ inputs.java_version }}
 
       - name: Build with Maven
-        uses: nimblehq/mulesoft-actions/build@v1.16.0
+        uses: nimblehq/mulesoft-actions/build@v1.23.0
         id: build
         with:
           use_artifacts: false
@@ -116,7 +116,7 @@ jobs:
           maven_settings_path: ${{ inputs.maven_settings_path }}
 
       - name: Deploy to CloudHub
-        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.20.0
+        uses: nimblehq/mulesoft-actions/deploy_cloudhub_1_0@v1.23.0
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}

--- a/.github/workflows/shared_deploy_cloudhub_1_0.yml
+++ b/.github/workflows/shared_deploy_cloudhub_1_0.yml
@@ -69,6 +69,8 @@ on:
         required: false
       BUSINESS_GROUP_ID:
         required: true
+      SECONDARY_BUSINESS_GROUP_ID:
+        required: false
       ENCRYPTION_KEY:
         required: true
       NEXUS_USERNAME:

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -28,6 +28,8 @@ on:
         required: true
       BUSINESS_GROUP_ID:
         required: true
+      SECONDARY_BUSINESS_GROUP_ID:
+        required: false
       NEXUS_USERNAME:
         required: false
       NEXUS_PASSWORD:
@@ -73,6 +75,7 @@ jobs:
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}
           maven_settings_path: ${{ inputs.maven_settings_path }}
           business_group_id: ${{ secrets.BUSINESS_GROUP_ID }}
+          secondary_business_group_id: ${{ secrets.SECONDARY_BUSINESS_GROUP_ID }}
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
           mule_file_path: ${{ steps.build.outputs.mule_file_path }}

--- a/.github/workflows/shared_deploy_exchange.yml
+++ b/.github/workflows/shared_deploy_exchange.yml
@@ -52,12 +52,12 @@ jobs:
           cat pom.xml
 
       - name: Set up Mulesoft environment
-        uses: nimblehq/mulesoft-actions/setup@v1.16.0
+        uses: nimblehq/mulesoft-actions/setup@v1.23.0
         with:
           java_version: ${{ inputs.java_version }}
 
       - name: Build with Maven
-        uses: nimblehq/mulesoft-actions/build@v1.16.0
+        uses: nimblehq/mulesoft-actions/build@v1.23.0
         id: build
         with:
           use_artifacts: false
@@ -69,7 +69,7 @@ jobs:
           maven_settings_path: ${{ inputs.maven_settings_path }}
 
       - name: Deploy to Anypoint Exchange
-        uses: nimblehq/mulesoft-actions/deploy_exchange@v1.22.0
+        uses: nimblehq/mulesoft-actions/deploy_exchange@v1.23.0
         with:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -34,6 +34,8 @@ on:
         required: false
       BUSINESS_GROUP_ID:
         required: false
+      SECONDARY_BUSINESS_GROUP_ID:
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -64,3 +66,4 @@ jobs:
           connected_app_client_id: ${{ secrets.CONTD_APP_CLIENT_ID }}
           connected_app_client_secret: ${{ secrets.CONTD_APP_CLIENT_SECRET }}
           business_group_id: ${{ secrets.BUSINESS_GROUP_ID }}
+          secondary_business_group_id: ${{ secrets.SECONDARY_BUSINESS_GROUP_ID }}

--- a/.github/workflows/shared_test.yml
+++ b/.github/workflows/shared_test.yml
@@ -51,12 +51,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Mulesoft environment
-        uses: nimblehq/mulesoft-actions/setup@v1.16.0
+        uses: nimblehq/mulesoft-actions/setup@v1.23.0
         with:
           java_version: ${{ inputs.java_version }}
 
       - name: Run MUnit tests
-        uses: nimblehq/mulesoft-actions/test@v1.16.0
+        uses: nimblehq/mulesoft-actions/test@v1.23.0
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/build/action.yml
+++ b/build/action.yml
@@ -18,6 +18,9 @@ inputs:
   business_group_id:
     description: Business group ID
     required: false
+  secondary_business_group_id:
+    description: Secondary business group ID
+    required: false
   nexus_username:
     description: Nexus username
     required: false
@@ -51,6 +54,7 @@ runs:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}
+        SECONDARY_BUSINESS_GROUP_ID: ${{ inputs.secondary_business_group_id }}
         NEXUS_USERNAME: ${{ inputs.nexus_username }}
         NEXUS_PASSWORD: ${{ inputs.nexus_password }}
         JAVA_TOOL_OPTIONS: ${{ env.JAVA_TOOL_OPTIONS }}

--- a/deploy_cloudhub_1_0/action.yml
+++ b/deploy_cloudhub_1_0/action.yml
@@ -28,6 +28,9 @@ inputs:
   business_group_id:
     description: Business group ID
     required: true
+  secondary_business_group_id:
+    description: Secondary business group ID
+    required: false
   cloudhub_region:
     description: CloudHub region
     required: true
@@ -93,6 +96,7 @@ runs:
         PLATFORM_CLIENT_SECRET: ${{ inputs.platform_client_secret }}
         CLOUDHUB_ENVIRONMENT: ${{ inputs.cloudhub_environment }}
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}
+        SECONDARY_BUSINESS_GROUP_ID: ${{ inputs.secondary_business_group_id }}
         CLOUDHUB_REGION: ${{ inputs.cloudhub_region }}
         CLOUDHUB_APPLICATION_NAME: ${{ inputs.cloudhub_application_name }}
         MULE_RUNTIME_VERSION: ${{ inputs.mule_runtime_version }}

--- a/deploy_exchange/action.yml
+++ b/deploy_exchange/action.yml
@@ -10,6 +10,9 @@ inputs:
   business_group_id:
     description: Business group ID
     required: true
+  secondary_business_group_id:
+    description: Secondary business group ID
+    required: false
   maven_settings_path:
     description: Maven settings file path
     required: true
@@ -41,3 +44,4 @@ runs:
         NEXUS_PASSWORD: ${{ inputs.nexus_password }}
         MULE_RUNTIME_VERSION: ${{ inputs.mule_runtime_version }}
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}
+        SECONDARY_BUSINESS_GROUP_ID: ${{ inputs.secondary_business_group_id }}

--- a/test/action.yml
+++ b/test/action.yml
@@ -29,6 +29,9 @@ inputs:
   business_group_id:
     description: Business group ID
     required: false
+  secondary_business_group_id:
+    description: Secondary business group ID
+    required: false
 
 runs:
   using: composite
@@ -47,6 +50,7 @@ runs:
         CONNECTED_APP_CLIENT_ID: ${{ inputs.connected_app_client_id }}
         CONNECTED_APP_CLIENT_SECRET: ${{ inputs.connected_app_client_secret }}
         BUSINESS_GROUP_ID: ${{ inputs.business_group_id }}
+        SECONDARY_BUSINESS_GROUP_ID: ${{ inputs.secondary_business_group_id }}
         JAVA_TOOL_OPTIONS: ${{ env.JAVA_TOOL_OPTIONS }}
 
     - name: Upload MUnit reports


### PR DESCRIPTION
## What happened 👀

- Add `SECONDARY_BUSINESS_GROUP_ID` to support download assets from the secondary exchange. In our case, CBTL would like to use the common-module from GT
- Update version for all workflows to use the newest one

## Insight 📝

- [x] Published the new change to https://github.com/nimblehq/mulesoft-actions/releases/tag/v1.23.0
- [x] Change jfc-global-actions: https://github.com/Jollibee-Foods-Corporation/jfc-global-actions/pull/29
- [ ] Update CBTL repositories to 

## Proof Of Work 📹

N/A
